### PR TITLE
Update to work for DotNetCore 2.2.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG BASE_IMAGE=mcr.microsoft.com/dotnet/core/sdk:2.2.401
+ARG BASE_IMAGE=mcr.microsoft.com/dotnet/core/sdk:2.2.207
 FROM $BASE_IMAGE AS build
-ARG CORECLR_BRANCH=v2.2.6
+ARG CORECLR_BRANCH=v2.2.8
 RUN apt-get update && \
 	apt-get install -y \
 		cmake \

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,6 @@
 
 docker build \
 	--tag 6opuc/lldb-netcore \
-	--build-arg BASE_IMAGE=mcr.microsoft.com/dotnet/core/sdk:2.2.401 \
-    --build-arg CORECLR_BRANCH=v2.2.6 \
+	--build-arg BASE_IMAGE=mcr.microsoft.com/dotnet/core/sdk:2.2.207 \
+    --build-arg CORECLR_BRANCH=v2.2.8 \
 	.


### PR DESCRIPTION
DotNetCore 2.2.8 is the most recent version of DotNetCore.  This updates the build and dockerfile to use 2.2.8